### PR TITLE
feature/optional_aligned_image

### DIFF
--- a/aicsshparam/shtools.py
+++ b/aicsshparam/shtools.py
@@ -184,7 +184,8 @@ def rotate_image_2d(image: np.array, angle: float, interpolation_order: int = 0)
 
 
 def align_image_2d(
-    image: np.array, alignment_channel: int = None, make_unique: bool = False
+    image: np.array, alignment_channel: int = None, make_unique: bool = False,
+    compute_aligned_image: bool = True,
 ):
 
     """Align a multichannel 3D image based on the channel
@@ -200,6 +201,8 @@ def align_image_2d(
         alignment will be propagated to all other channels.
     make_unique : bool
         Set true to make sure the alignment rotation is unique.
+    compute_aligned_image : bool
+        Set false to only compute and return the alignment angle
     Returns
     -------
     img_aligned : np.array
@@ -258,10 +261,13 @@ def align_image_2d(
         if np.abs(eigenvecs[0][0]) > EPS:
             angle = 180.0 * np.arctan(eigenvecs[0][1] / eigenvecs[0][0]) / np.pi
 
-    # Apply skimage rotation clock-wise
-    img_aligned = rotate_image_2d(image=image, angle=angle)
+    if compute_aligned_image:
+        # Apply skimage rotation clock-wise
+        img_aligned = rotate_image_2d(image=image, angle=angle)
 
-    return img_aligned, angle
+        return img_aligned, angle
+
+    return angle
 
 
 def apply_image_alignment_2d(image: np.array, angle: float):

--- a/aicsshparam/shtools.py
+++ b/aicsshparam/shtools.py
@@ -184,7 +184,9 @@ def rotate_image_2d(image: np.array, angle: float, interpolation_order: int = 0)
 
 
 def align_image_2d(
-    image: np.array, alignment_channel: int = None, make_unique: bool = False,
+    image: np.array,
+    alignment_channel: int = None,
+    make_unique: bool = False,
     compute_aligned_image: bool = True,
 ):
 


### PR DESCRIPTION
Added a flag to `align_image_2d` to optionally disable the computation of the aligned image, and return only the angle. The current behaviour (where the aligned image *is* computed) remains the default, so as to maintain compatibility
