### PR TITLE
Remove weekly build

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -4,11 +4,6 @@ on:
   push:
     branches:
       - main
-  schedule:
-    # <minute [0,59]> <hour [0,23]> <day of the month [1,31]> <month of the year [1,12]> <day of the week [0,6]>
-    # https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#tag_20_25_07
-    # Run every Monday at 18:00:00 UTC (Monday at 10:00:00 PST)
-    - cron: '0 18 * * 1'
 
 jobs:
   test:


### PR DESCRIPTION
The latest release was not pushed to pypi automatically, because Github disables workflows triggered on a schedule if the repository is not touched for 60 days (see screenshot). Removing the weekly trigger (hopefully) allows the workflow to stay enabled to be triggered by new releases.

![Screen Shot 2022-11-03 at 10 46 11 AM](https://user-images.githubusercontent.com/5379348/199814319-49ea7ffc-a454-475b-81a3-63f96974ef9c.png)
