### PR TITLE
Fix syntax for black linter

### DIFF
--- a/aicsshparam/shparam.py
+++ b/aicsshparam/shparam.py
@@ -142,7 +142,7 @@ def get_shcoeffs(
     mesh = shtools.update_mesh_points(mesh, x, y, z)
 
     # Cartesian to spherical coordinates convertion
-    rad = np.sqrt(x ** 2 + y ** 2 + z ** 2)
+    rad = np.sqrt(x**2 + y**2 + z**2)
     lat = np.arccos(np.divide(z, rad, out=np.zeros_like(rad), where=(rad != 0)))
     lon = np.pi + np.arctan2(y, x)
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup_requirements = [
 ]
 
 test_requirements = [
-    "black>=19.10b0",
+    "black>=22.10.0",
     "codecov>=2.1.4",
     "flake8>=3.8.3",
     "flake8-debugger>=3.2.1",


### PR DESCRIPTION
The latest release [failed to pass the linting check](https://github.com/AllenCell/aics-shparam/actions/runs/3388947844). This is the change recommended by `black` at version 22.10.0, and with this change `black` now passes.

I've updated the required version of `black` because it seems likely that some older versions would prefer the formatting as it was before