### PR TITLE
Unpin pyshtools version in setup.py

### DIFF
--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.8, 3.9]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ requirements = [
     'scikit-image>=0.16.2',
     'scikit-learn>=0.22.1',
     'vtk>=9.0.1',
-    'pyshtools==4.9.1'
+    'pyshtools>=4.9.1'
 ]
 
 extra_requirements = {


### PR DESCRIPTION
Unpinned the `pyshtools` version in `setup.py` from `4.9.1` to allow installation with Python 3.10+. Version `4.9.1` of `pyshtools` only has wheel builds up to [Python 3.9](https://pypi.org/project/pyshtools/4.9.1/#files).
