### PR TITLE
remove version pin for an old hacky fix, add schedule for build-main

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - main
+  schedule:
+    # <minute [0,59]> <hour [0,23]> <day of the month [1,31]> <month of the year [1,12]> <day of the week [0,6]>
+    # https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#tag_20_25_07
+    # Run every Monday at 18:00:00 UTC (Monday at 10:00:00 PST)
+    - cron: '0 18 1 * *'
 
 jobs:
   test:

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ requirements = [
     'scikit-image',
     'scikit-learn',
     'vtk',
-    'pyshtools==4.10.4',#4.11+ seems to be broken with Python3.9+
+    'pyshtools',
 ]
 
 extra_requirements = {


### PR DESCRIPTION
remove a version pin (hacky fix on a broken build before the paper release)
add schedule for building main
