### PR TITLE
Revert Python Version to 3.9 for Documentation Build Workflow

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -17,17 +17,13 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.12'
+          python-version: '3.9'
           cache: 'pip'
 
       - name: Install Dependencies
         run: |
-          python -m pip install --upgrade pip setuptools
+          python -m pip install --upgrade pip
           pip install .[dev]
-
-      - name: Verify m2r2 Installation
-        run: |
-          python -c "import m2r2"
 
       - name: Generate Docs
         run: |

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -22,8 +22,12 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip setuptools
           pip install .[dev]
+
+      - name: Verify m2r2 Installation
+        run: |
+          python -c "import m2r2"
 
       - name: Generate Docs
         run: |

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.12'  
+          python-version: '3.9'  
           
       - name: Install Dependencies
         run: |


### PR DESCRIPTION
## Summary
This PR reverts the Python version used in the GitHub Actions workflow for building the project documentation from Python **3.12** back to **3.9**. The change addresses the build failures encountered when using Python 3.12, ensuring that the documentation builds successfully as it did previously. An attempt was made to update the GitHub Actions workflow to use Python **3.12** for building the documentation. However, this resulted in the following error:

```
Extension error:
Could not import extension m2r2 (exception: No module named 'pkg_resources')
```

This error indicates compatibility issues between the documentation build process and Python 3.12, likely related to dependencies that are not yet fully compatible with the latest Python version.


